### PR TITLE
Improve overlay service and cleanup Kotlin

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/notifications/SchedulerEnabledFragment.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/notifications/SchedulerEnabledFragment.kt
@@ -91,8 +91,8 @@ class SchedulerEnabledFragment : Fragment() {
         val scheduleToMinute = sharedPreferences.getInt("scheduleToMinute", 0)
 
         val cNow = Calendar.getInstance()
-        val cStart = SchedulerService._getCalendarForStart(requireContext())
-        val cEnd = SchedulerService._getCalendarForEnd(requireContext())
+        val cStart = SchedulerService.getCalendarForStart(requireContext())
+        val cEnd = SchedulerService.getCalendarForEnd(requireContext())
 
         timer?.cancel()
 

--- a/app/src/main/java/com/d4rk/lowbrightness/services/OverlayService.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/services/OverlayService.kt
@@ -21,7 +21,7 @@ import com.d4rk.lowbrightness.base.Prefs
 import com.d4rk.lowbrightness.ui.views.OverlayView
 
 class OverlayService : Service() {
-    private var mView : OverlayView? = null
+    private var overlayView: OverlayView? = null
 
     override fun onBind(intent : Intent) : IBinder? = null
 
@@ -36,18 +36,23 @@ class OverlayService : Service() {
         val opacityPercentage = sharedPreferences.getInt(Constants.PREF_DIM_LEVEL , 20)
         val color = sharedPreferences.getInt(Constants.PREF_OVERLAY_COLOR , Color.BLACK)
 
-        if (mView == null) {
-            mView = OverlayView(this).apply {
-                setOpacityPercentage(opacityPercentage)
-                setColor(color)
+        if (overlayView == null) {
+            overlayView = OverlayView(this).apply {
+                this.opacityPercentage = opacityPercentage
+                this.color = color
             }
 
             val params = WindowManager.LayoutParams(
-                WindowManager.LayoutParams.MATCH_PARENT ,
-                WindowManager.LayoutParams.MATCH_PARENT ,
-                WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY ,
-                WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or WindowManager.LayoutParams.FLAG_FULLSCREEN or
-                        WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS ,
+                WindowManager.LayoutParams.MATCH_PARENT,
+                WindowManager.LayoutParams.MATCH_PARENT,
+                WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
+                WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                        WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                        WindowManager.LayoutParams.FLAG_FULLSCREEN or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                        WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS or
+                        WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED,
                 PixelFormat.TRANSLUCENT
             ).apply {
                 gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
@@ -56,13 +61,11 @@ class OverlayService : Service() {
             }
 
             val wm = getSystemService(WINDOW_SERVICE) as WindowManager
-            wm.addView(mView , params)
-        }
-        else {
-            mView?.apply {
-                setOpacityPercentage(opacityPercentage)
-                setColor(color)
-                redraw()
+            wm.addView(overlayView, params)
+        } else {
+            overlayView?.apply {
+                this.opacityPercentage = opacityPercentage
+                this.color = color
             }
         }
 
@@ -103,9 +106,9 @@ class OverlayService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
-        mView?.let {
+        overlayView?.let {
             (getSystemService(WINDOW_SERVICE) as WindowManager).removeView(it)
-            mView = null
+            overlayView = null
         }
         stopForeground(true)
     }

--- a/app/src/main/java/com/d4rk/lowbrightness/services/SchedulerService.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/services/SchedulerService.kt
@@ -47,10 +47,10 @@ class SchedulerService : Service() {
     private fun startOrStopScreenDim() {
         val sharedPreferences = Prefs.get(baseContext)
         if (sharedPreferences.getBoolean(Constants.PREF_LOW_BRIGHTNESS_ENABLED , false)) {
-            val cBegin = _getCalendarForStart(
-                baseContext
-            )
-            val cEnd = _getCalendarForEnd(baseContext)
+        val cBegin = getCalendarForStart(
+            baseContext
+        )
+        val cEnd = getCalendarForEnd(baseContext)
             val calendar = Calendar.getInstance()
             if (calendar.timeInMillis > cBegin.timeInMillis && calendar.timeInMillis < cEnd.timeInMillis) {
                 startService(Intent(baseContext , OverlayService::class.java))
@@ -83,7 +83,7 @@ class SchedulerService : Service() {
 
     companion object {
         @JvmStatic
-        fun _getCalendarForStart(context : Context) : Calendar { // FIXME: Function name '_getCalendarForStart' should start with a lowercase letter
+        fun getCalendarForStart(context: Context): Calendar {
             val sharedPreferences = Prefs.get(context)
             val scheduleFromHour = sharedPreferences.getInt("scheduleFromHour" , 20)
             val scheduleFromMinute = sharedPreferences.getInt("scheduleFromMinute" , 0)
@@ -95,7 +95,7 @@ class SchedulerService : Service() {
         }
 
         @JvmStatic
-        fun _getCalendarForEnd(context : Context) : Calendar { // FIXME: Function name '_getCalendarForEnd' should start with a lowercase letter
+        fun getCalendarForEnd(context: Context): Calendar {
             val sharedPreferences = Prefs.get(context)
             val hour = sharedPreferences.getInt("scheduleToHour" , 6)
             val minute = sharedPreferences.getInt("scheduleToMinute" , 0)
@@ -103,7 +103,7 @@ class SchedulerService : Service() {
             calendar[Calendar.HOUR_OF_DAY] = hour
             calendar[Calendar.MINUTE] = minute
             calendar.clear(Calendar.SECOND)
-            if (calendar.timeInMillis < _getCalendarForStart(context).timeInMillis) {
+            if (calendar.timeInMillis < getCalendarForStart(context).timeInMillis) {
                 calendar.add(Calendar.DATE , 1)
             }
             return calendar

--- a/app/src/main/java/com/d4rk/lowbrightness/ui/about/AboutFragment.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/ui/about/AboutFragment.kt
@@ -14,7 +14,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.d4rk.lowbrightness.BuildConfig
 import com.d4rk.lowbrightness.R
 import com.d4rk.lowbrightness.databinding.FragmentAboutBinding
-import com.d4rk.lowbrightness.ui.viewmodel.ViewModel
+import com.d4rk.lowbrightness.ui.viewmodel.AboutViewModel
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.MobileAds
 import com.google.android.material.snackbar.Snackbar
@@ -28,7 +28,7 @@ class AboutFragment : Fragment() {
     private val calendar: Calendar = Calendar.getInstance()
     private var originalNavBarColor: Int? = null
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        ViewModelProvider(this)[ViewModel::class.java]
+        ViewModelProvider(this)[AboutViewModel::class.java]
         _binding = FragmentAboutBinding.inflate(inflater, container, false)
         originalNavBarColor = activity?.window?.navigationBarColor
         setOriginalNavigationBarColor()

--- a/app/src/main/java/com/d4rk/lowbrightness/ui/viewmodel/AboutViewModel.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/ui/viewmodel/AboutViewModel.kt
@@ -1,3 +1,5 @@
 package com.d4rk.lowbrightness.ui.viewmodel
+
 import androidx.lifecycle.ViewModel
-class ViewModel : ViewModel()
+
+class AboutViewModel : ViewModel()

--- a/app/src/main/java/com/d4rk/lowbrightness/ui/views/OverlayView.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/ui/views/OverlayView.kt
@@ -5,40 +5,28 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import androidx.appcompat.widget.AppCompatImageView
 
-class OverlayView(context : Context) : AppCompatImageView(context) {
+class OverlayView(context: Context) : AppCompatImageView(context) {
 
-    private val loadPaint : Paint = Paint().apply {
+    private val paint: Paint = Paint().apply {
         isAntiAlias = true
         textSize = 10f
-        color = color
-        alpha = 255 / 100 * opacityPercentage
     }
 
-    private var opacityPercentage : Int = 0
+    var opacityPercentage: Int = 0
+        set(value) {
+            field = value
+            paint.alpha = 255 * value / 100
+            invalidate()
+        }
 
-    private var color : Int = 0
+    var color: Int = 0
+        set(value) {
+            field = value
+            paint.color = value
+            invalidate()
+        }
 
-    override fun onDraw(canvas : Canvas) {
-        super.onDraw(canvas)
-        canvas.drawPaint(loadPaint)
-    }
-
-    fun redraw() {
-        invalidate()
-    }
-
-    fun setOpacityPercentage(opacityPercentage : Int) {
-        loadPaint.alpha = 255 / 100 * opacityPercentage
-        this.opacityPercentage = opacityPercentage
-    }
-
-    fun setColor(color : Int) {
-        loadPaint.color = color
-        setOpacityPercentage(opacityPercentage)
-        this.color = color
-    }
-
-    fun getColor() : Int {
-        return color
+    override fun onDraw(canvas: Canvas) {
+        canvas.drawPaint(paint)
     }
 }


### PR DESCRIPTION
## Summary
- make view model a dedicated `AboutViewModel`
- rename scheduler helper methods for idiomatic style
- show overlay on lock screen and simplify overlay view updates
- update fragments to use new APIs

## Testing
- `./gradlew tasks --all`
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b607e6b8832d955b550ca485b2f8