### PR TITLE
Fix deprecated Android APIs

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/helpers/RequestDrawOverAppsPermission.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/helpers/RequestDrawOverAppsPermission.kt
@@ -4,28 +4,22 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import androidx.activity.result.ActivityResultLauncher
 import com.d4rk.lowbrightness.base.Application.canDrawOverlay
 
 class RequestDrawOverAppsPermission(private val activity : Activity) {
-    fun requestCodeMatches(requestCode : Int) : Boolean {
-        return REQUEST_CODE == requestCode
-    }
 
     fun canDrawOverlays() : Boolean {
         return canDrawOverlay(activity)
     }
 
-    fun requestPermissionDrawOverOtherApps() {
-        if (! Settings.canDrawOverlays(activity)) {
+    fun requestPermissionDrawOverOtherApps(launcher: ActivityResultLauncher<Intent>) {
+        if (!Settings.canDrawOverlays(activity)) {
             val intent = Intent(
-                Settings.ACTION_MANAGE_OVERLAY_PERMISSION ,
+                Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
                 Uri.parse("package:" + activity.packageName)
             )
-            activity.startActivityForResult(intent , REQUEST_CODE)
+            launcher.launch(intent)
         }
-    }
-
-    companion object {
-        private const val REQUEST_CODE = 5463
     }
 }

--- a/app/src/main/java/com/d4rk/lowbrightness/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/ui/home/HomeFragment.kt
@@ -64,15 +64,16 @@ class HomeFragment : Fragment() {
 
     private fun showPermissionDialog(permissionRequester: RequestDrawOverAppsPermission) {
         MaterialAlertDialogBuilder(requireContext())
-                .setTitle(R.string.notification_app_needs_permission_title)
-                .setIcon(R.drawable.ic_eye)
-                .setMessage(R.string.summary_app_needs_permission)
-                .setCancelable(false)
-                .setPositiveButton(R.string.allow_permission) { dialog, _ ->
-                    dialog.cancel()
-                    permissionRequester.requestPermissionDrawOverOtherApps()
-                }
-                .show()
+            .setTitle(R.string.notification_app_needs_permission_title)
+            .setIcon(R.drawable.ic_eye)
+            .setMessage(R.string.summary_app_needs_permission)
+            .setCancelable(false)
+            .setPositiveButton(R.string.allow_permission) { dialog, _ ->
+                dialog.cancel()
+                val launcher = (requireActivity() as MainActivity).overlayPermissionLauncher
+                permissionRequester.requestPermissionDrawOverOtherApps(launcher)
+            }
+            .show()
     }
 
     private fun setupColorPicker() {


### PR DESCRIPTION
## Summary
- update overlay permission flow to use `ActivityResultLauncher`
- switch Play Core update API to new `AppUpdateOptions` overload

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b64c0478832dbda7826ed9434960