### PR TITLE
Add helper extensions and refactor URL/clipboard actions

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/helpers/ContextExtensions.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/helpers/ContextExtensions.kt
@@ -1,0 +1,18 @@
+package com.d4rk.lowbrightness.helpers
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.content.ClipboardManager
+import android.content.ClipData
+
+fun Context.openUrl(url: String) {
+    startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+}
+
+fun Context.copyToClipboard(text: CharSequence) {
+    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = ClipData.newPlainText("text", text)
+    clipboard.setPrimaryClip(clip)
+}
+

--- a/app/src/main/java/com/d4rk/lowbrightness/ui/about/AboutFragment.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/ui/about/AboutFragment.kt
@@ -1,9 +1,4 @@
 package com.d4rk.lowbrightness.ui.about
-import android.content.ClipData
-import android.content.Intent
-import android.content.Context
-import android.content.ClipboardManager
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -15,6 +10,8 @@ import com.d4rk.lowbrightness.BuildConfig
 import com.d4rk.lowbrightness.R
 import com.d4rk.lowbrightness.databinding.FragmentAboutBinding
 import com.d4rk.lowbrightness.ui.viewmodel.AboutViewModel
+import com.d4rk.lowbrightness.helpers.copyToClipboard
+import com.d4rk.lowbrightness.helpers.openUrl
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.MobileAds
 import com.google.android.material.snackbar.Snackbar
@@ -42,33 +39,31 @@ class AboutFragment : Fragment() {
         val copyright = requireContext().getString(R.string.copyright, dateText)
         binding.textViewCopyright.text = copyright
         binding.textViewAppVersion.setOnLongClickListener {
-            val clipboardManager = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            val clipData: ClipData = ClipData.newPlainText("Label", binding.textViewAppVersion.text)
-            clipboardManager.setPrimaryClip(clipData)
+            requireContext().copyToClipboard(binding.textViewAppVersion.text)
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2)
                 Snackbar.make(requireView(), R.string.snack_copied_to_clipboard, Snackbar.LENGTH_SHORT).show()
             true
         }
         binding.imageViewAppIcon.setOnClickListener {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://sites.google.com/view/d4rk7355608")))
+            requireContext().openUrl("https://sites.google.com/view/d4rk7355608")
         }
         binding.chipGoogleDev.setOnClickListener {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://g.dev/D4rK7355608")))
+            requireContext().openUrl("https://g.dev/D4rK7355608")
         }
         binding.chipYoutube.setOnClickListener {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://www.youtube.com/c/D4rK7355608")))
+            requireContext().openUrl("https://www.youtube.com/c/D4rK7355608")
         }
         binding.chipGithub.setOnClickListener {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/D4rK7355608/" + BuildConfig.APPLICATION_ID)))
+            requireContext().openUrl("https://github.com/D4rK7355608/" + BuildConfig.APPLICATION_ID)
         }
         binding.chipTwitter.setOnClickListener {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://twitter.com/D4rK7355608")))
+            requireContext().openUrl("https://twitter.com/D4rK7355608")
         }
         binding.chipXda.setOnClickListener {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://forum.xda-developers.com/m/d4rk7355608.10095012")))
+            requireContext().openUrl("https://forum.xda-developers.com/m/d4rk7355608.10095012")
         }
         binding.chipMusic.setOnClickListener {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://sites.google.com/view/d4rk7355608/tracks")))
+            requireContext().openUrl("https://sites.google.com/view/d4rk7355608/tracks")
         }
         return binding.root
     }

--- a/app/src/main/java/com/d4rk/lowbrightness/ui/help/HelpActivity.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/ui/help/HelpActivity.kt
@@ -1,7 +1,6 @@
 package com.d4rk.lowbrightness.ui.help
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -13,6 +12,7 @@ import com.d4rk.lowbrightness.databinding.ActivityHelpBinding
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.play.core.review.ReviewManager
 import com.google.android.play.core.review.ReviewManagerFactory
+import com.d4rk.lowbrightness.helpers.openUrl
 class HelpActivity : AppCompatActivity() {
     private lateinit var binding: ActivityHelpBinding
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,11 +39,9 @@ class HelpActivity : AppCompatActivity() {
                     reviewManager.launchReviewFlow(requireActivity(), reviewInfo)
                 }
                 .addOnFailureListener {
-                    val uri = Uri.parse("https://play.google.com/store/apps/details?id=${requireContext().packageName}&showAllReviews=true")
-                    val intent = Intent(Intent.ACTION_VIEW, uri)
-                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    val uri = "https://play.google.com/store/apps/details?id=${requireContext().packageName}&showAllReviews=true"
                     try {
-                        startActivity(intent)
+                        requireContext().openUrl(uri)
                     } catch (e: ActivityNotFoundException) {
                         Snackbar.make(requireView(), R.string.snack_unable_to_open_google_play_store, Snackbar.LENGTH_SHORT).show()
                     }

--- a/app/src/main/java/com/d4rk/lowbrightness/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/ui/settings/SettingsActivity.kt
@@ -1,9 +1,7 @@
 package com.d4rk.lowbrightness.ui.settings
 import android.content.Context
-import android.content.ClipData
 import android.content.SharedPreferences
 import android.content.Intent
-import android.content.ClipboardManager
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -19,6 +17,7 @@ import com.d4rk.lowbrightness.databinding.ActivitySettingsBinding
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
+import com.d4rk.lowbrightness.helpers.copyToClipboard
 
 class SettingsActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceChangeListener {
     private lateinit var binding: ActivitySettingsBinding
@@ -91,9 +90,7 @@ class SettingsActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferen
             )
             deviceInfoPreference?.summary = version
             deviceInfoPreference?.setOnPreferenceClickListener {
-                val clipboard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                val clip = ClipData.newPlainText("text", version)
-                clipboard.setPrimaryClip(clip)
+                requireContext().copyToClipboard(version)
                 if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
                     Snackbar.make(requireView(), R.string.snack_copied_to_clipboard, Snackbar.LENGTH_SHORT).show()
                 }

--- a/app/src/main/java/com/d4rk/lowbrightness/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/ui/startup/StartupActivity.kt
@@ -1,7 +1,6 @@
 package com.d4rk.lowbrightness.ui.startup
 import android.Manifest
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -12,6 +11,7 @@ import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
 import com.google.android.ump.UserMessagingPlatform
 import me.zhanghai.android.fastscroll.FastScrollerBuilder
+import com.d4rk.lowbrightness.helpers.openUrl
 class StartupActivity : AppCompatActivity() {
     private lateinit var binding: ActivityStartupBinding
     private lateinit var consentInformation: ConsentInformation
@@ -33,7 +33,7 @@ class StartupActivity : AppCompatActivity() {
         })
         FastScrollerBuilder(binding.scrollView).useMd2Style().build()
         binding.buttonBrowsePrivacyPolicyAndTermsOfService.setOnClickListener {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://sites.google.com/view/d4rk7355608/more/apps/privacy-policy")))
+            openUrl("https://sites.google.com/view/d4rk7355608/more/apps/privacy-policy")
         }
         binding.floatingButtonAgree.setOnClickListener {
             startActivity(Intent(this, MainActivity::class.java))


### PR DESCRIPTION
## Summary
- introduce `ContextExtensions` with common helpers
- use `openUrl` and `copyToClipboard` throughout the app
- remove redundant imports and clean up related code

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bbe25800832da6b9957b2e760103