### PR TITLE
Fix overlay service crash

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/base/ServiceController.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/base/ServiceController.kt
@@ -18,12 +18,13 @@ object ServiceController {
         val overlayEnabled = OverlayService.isEnabled(context)
         val schedulerEnabled = SchedulerService.isEnabled(context)
         val accessibilityEnabled = AccessibilityOverlayService.isEnabled(context)
+        val canDrawOverlay = canDrawOverlay(context)
 
         val overlayIntent = Intent(context, OverlayService::class.java)
         val schedulerIntent = Intent(context, SchedulerService::class.java)
         val accessibilityIntent = Intent(context, AccessibilityOverlayService::class.java)
 
-        if (overlayEnabled) {
+        if (overlayEnabled && canDrawOverlay) {
             if (schedulerEnabled) {
                 context.stopService(overlayIntent)
                 ContextCompat.startForegroundService(context, schedulerIntent)

--- a/app/src/main/java/com/d4rk/lowbrightness/services/SchedulerService.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/services/SchedulerService.kt
@@ -56,7 +56,8 @@ class SchedulerService : Service() {
     private fun startOrStopScreenDim() {
         Log.d(tag, "Evaluating schedule")
         val sharedPreferences = Prefs.get(baseContext)
-        if (sharedPreferences.getBoolean(Constants.PREF_LOW_BRIGHTNESS_ENABLED, false)) {
+        if (sharedPreferences.getBoolean(Constants.PREF_LOW_BRIGHTNESS_ENABLED, false) &&
+            ServiceController.canDrawOverlay(baseContext)) {
             val cBegin = getCalendarForStart(baseContext)
             val cEnd = getCalendarForEnd(baseContext)
             val calendar = Calendar.getInstance()
@@ -72,7 +73,7 @@ class SchedulerService : Service() {
             }
         } else {
             val overlayIntent = Intent(baseContext, OverlayService::class.java)
-            Log.d(tag, "Overlay disabled via prefs")
+            Log.d(tag, "Overlay disabled via prefs or permission missing")
             stopService(overlayIntent)
         }
     }


### PR DESCRIPTION
## Summary
- avoid starting overlay service if overlay permission isn't granted
- check overlay permission before scheduling overlay service

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684143b167a0832d8c6cf5f5d826a370