### PR TITLE
Switch scheduler to WorkManager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,6 +120,7 @@ dependencies {
     implementation("com.wdullaer:materialdatetimepicker:4.2.3")
     implementation("com.thebluealliance:spectrum:0.7.1")
     implementation("me.zhanghai.android.fastscroll:library:1.3.0")
+    implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.coroutines.play.services)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="com.android.vending.CHECK_LICENSE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
     <uses-permission android:name="android.permission.WRITE_SETTINGS" tools:ignore="ProtectedPermissions"/>
@@ -62,9 +61,6 @@
                 android:name="android.accessibilityservice"
                 android:resource="@xml/accessibility_service_config" />
         </service>
-        <service
-            android:name=".services.SchedulerService"
-            android:enabled="true"/>
         <receiver
             android:name=".receivers.OnBootBroadcastReceiver"
             android:enabled="true"

--- a/app/src/main/java/com/d4rk/lowbrightness/base/ServiceController.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/base/ServiceController.kt
@@ -21,15 +21,14 @@ object ServiceController {
         val canDrawOverlay = canDrawOverlay(context)
 
         val overlayIntent = Intent(context, OverlayService::class.java)
-        val schedulerIntent = Intent(context, SchedulerService::class.java)
         val accessibilityIntent = Intent(context, AccessibilityOverlayService::class.java)
 
         if (overlayEnabled && canDrawOverlay) {
             if (schedulerEnabled) {
+                SchedulerService.enable(context) // ensures work scheduled
                 context.stopService(overlayIntent)
-                ContextCompat.startForegroundService(context, schedulerIntent)
             } else {
-                context.stopService(schedulerIntent)
+                SchedulerService.disable(context) // ensures work cancelled
                 ContextCompat.startForegroundService(context, overlayIntent)
             }
 
@@ -37,7 +36,7 @@ object ServiceController {
                 context.startService(accessibilityIntent)
             }
         } else {
-            context.stopService(schedulerIntent)
+            SchedulerService.disable(context)
             context.stopService(overlayIntent)
             context.stopService(accessibilityIntent)
         }

--- a/app/src/main/java/com/d4rk/lowbrightness/notifications/SchedulerDisabledFragment.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/notifications/SchedulerDisabledFragment.kt
@@ -1,11 +1,7 @@
 package com.d4rk.lowbrightness.notifications
 
-import android.app.AlarmManager
 import android.content.Context
-import android.content.Intent
-import android.os.Build
 import android.os.Bundle
-import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -24,15 +20,6 @@ class SchedulerDisabledFragment : Fragment() {
     ): View {
         val binding = FragmentSchedulerDisabledBinding.inflate(inflater, container, false)
         binding.buttonSchedule.setOnClickListener {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                val alarmManager = context?.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
-                if (alarmManager != null && !alarmManager.canScheduleExactAlarms()) {
-                    val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
-                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    startActivity(intent)
-                    return@setOnClickListener
-                }
-            }
             context?.let { SchedulerService.enable(it) }
             bridge.showOrHideSchedulerUI(true)
         }

--- a/app/src/main/java/com/d4rk/lowbrightness/services/SchedulerService.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/services/SchedulerService.kt
@@ -1,153 +1,115 @@
 package com.d4rk.lowbrightness.services
 
-import android.app.AlarmManager
-import android.app.PendingIntent
-import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.os.IBinder
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
-import android.util.Log
-import com.d4rk.lowbrightness.base.ServiceController
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
 import com.d4rk.lowbrightness.base.Constants
 import com.d4rk.lowbrightness.base.Prefs
+import com.d4rk.lowbrightness.base.ServiceController
 import java.util.Calendar
+import java.util.concurrent.TimeUnit
 
-class SchedulerService : Service() {
-    private val tag = "SchedulerService"
-    override fun onCreate() {
-        super.onCreate()
-        Log.d(tag, "onCreate")
-        val am = baseContext.getSystemService(ALARM_SERVICE) as AlarmManager
-        val iEnd = Intent(baseContext , SchedulerService::class.java)
-        val piEnd = PendingIntent.getService(
-            baseContext ,
-            0 ,
-            iEnd ,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-        Log.d(tag, "Scheduling hourly checks")
-        am.setInexactRepeating(
-            AlarmManager.RTC,
-            System.currentTimeMillis(),
-            AlarmManager.INTERVAL_HOUR,
-            piEnd
-        )
-    }
+object SchedulerService {
+    private const val WORK_NAME = "SchedulerWorker"
+    private const val TAG = "SchedulerService"
 
-    override fun onBind(intent : Intent) : IBinder? {
-        throw UnsupportedOperationException("Not yet implemented")
-    }
-
-    override fun onStartCommand(intent : Intent , flags : Int , startId : Int) : Int {
-        Log.d(tag, "onStartCommand")
-        if (! Prefs.get(baseContext).getBoolean(Constants.PREF_SCHEDULER_ENABLED , false)) {
-            cancelAlarms()
-            stopSelf()
-            return START_NOT_STICKY
-        }
-        else {
-            startOrStopScreenDim()
-            return START_STICKY
-        }
-    }
-
-    private fun startOrStopScreenDim() {
-        Log.d(tag, "Evaluating schedule")
-        val sharedPreferences = Prefs.get(baseContext)
+    fun evaluateSchedule(context: Context) {
+        Log.d(TAG, "Evaluating schedule")
+        val sharedPreferences = Prefs.get(context)
         if (sharedPreferences.getBoolean(Constants.PREF_LOW_BRIGHTNESS_ENABLED, false) &&
-            ServiceController.canDrawOverlay(baseContext)) {
-            val cBegin = getCalendarForStart(baseContext)
-            val cEnd = getCalendarForEnd(baseContext)
+            ServiceController.canDrawOverlay(context)
+        ) {
+            val cBegin = getCalendarForStart(context)
+            val cEnd = getCalendarForEnd(context)
             val calendar = Calendar.getInstance()
 
-            val overlayIntent = Intent(baseContext, OverlayService::class.java)
+            val overlayIntent = Intent(context, OverlayService::class.java)
 
             if (calendar.timeInMillis > cBegin.timeInMillis && calendar.timeInMillis < cEnd.timeInMillis) {
-                Log.d(tag, "Enabling overlay")
-                ContextCompat.startForegroundService(baseContext, overlayIntent)
+                Log.d(TAG, "Enabling overlay")
+                ContextCompat.startForegroundService(context, overlayIntent)
             } else {
-                Log.d(tag, "Disabling overlay")
-                stopService(overlayIntent)
+                Log.d(TAG, "Disabling overlay")
+                context.stopService(overlayIntent)
             }
         } else {
-            val overlayIntent = Intent(baseContext, OverlayService::class.java)
-            Log.d(tag, "Overlay disabled via prefs or permission missing")
-            stopService(overlayIntent)
+            val overlayIntent = Intent(context, OverlayService::class.java)
+            Log.d(TAG, "Overlay disabled via prefs or permission missing")
+            context.stopService(overlayIntent)
         }
     }
 
-    override fun onDestroy() {
-        Log.d(tag, "onDestroy")
-        cancelAlarms()
-        super.onDestroy()
-    }
-
-    private fun cancelAlarms() {
-        val alarmManager = baseContext.getSystemService(ALARM_SERVICE) as AlarmManager
-        Log.d(tag, "Cancelling scheduled alarms")
-        val iBegin = Intent(baseContext , SchedulerService::class.java)
-        val piBegin = PendingIntent.getService(
-            baseContext ,
-            0 ,
-            iBegin ,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    private fun scheduleWork(context: Context) {
+        Log.d(TAG, "Scheduling hourly checks with WorkManager")
+        val request = PeriodicWorkRequestBuilder<SchedulerWorker>(1, TimeUnit.HOURS)
+            .build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            WORK_NAME,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
         )
-        alarmManager.cancel(piBegin)
-        Log.d(tag, "Alarms cancelled")
     }
 
-    companion object {
-        @JvmStatic
-        fun getCalendarForStart(context: Context): Calendar {
-            val sharedPreferences = Prefs.get(context)
-            val scheduleFromHour = sharedPreferences.getInt("scheduleFromHour" , 20)
-            val scheduleFromMinute = sharedPreferences.getInt("scheduleFromMinute" , 0)
-            val calendar = Calendar.getInstance()
-            calendar[Calendar.HOUR_OF_DAY] = scheduleFromHour
-            calendar[Calendar.MINUTE] = scheduleFromMinute
-            calendar.clear(Calendar.SECOND)
-            return calendar
-        }
+    private fun cancelWork(context: Context) {
+        Log.d(TAG, "Cancelling WorkManager tasks")
+        WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+    }
 
-        @JvmStatic
-        fun getCalendarForEnd(context: Context): Calendar {
-            val sharedPreferences = Prefs.get(context)
-            val hour = sharedPreferences.getInt("scheduleToHour" , 6)
-            val minute = sharedPreferences.getInt("scheduleToMinute" , 0)
-            val calendar = Calendar.getInstance()
-            calendar[Calendar.HOUR_OF_DAY] = hour
-            calendar[Calendar.MINUTE] = minute
-            calendar.clear(Calendar.SECOND)
-            if (calendar.timeInMillis < getCalendarForStart(context).timeInMillis) {
-                calendar.add(Calendar.DATE , 1)
-            }
-            return calendar
+    @JvmStatic
+    fun getCalendarForStart(context: Context): Calendar {
+        val sharedPreferences = Prefs.get(context)
+        val scheduleFromHour = sharedPreferences.getInt("scheduleFromHour", 20)
+        val scheduleFromMinute = sharedPreferences.getInt("scheduleFromMinute", 0)
+        return Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, scheduleFromHour)
+            set(Calendar.MINUTE, scheduleFromMinute)
+            clear(Calendar.SECOND)
         }
+    }
 
-        @JvmStatic
-        fun isEnabled(context : Context) : Boolean {
-            val prefs = Prefs.get(context)
-            return prefs.getBoolean(Constants.PREF_SCHEDULER_ENABLED , false)
-        }
-
-        @JvmStatic
-        fun enable(context: Context) {
-            val prefs = Prefs.get(context)
-            if (!prefs.getBoolean(Constants.PREF_SCHEDULER_ENABLED, false)) {
-                prefs.edit { putBoolean(Constants.PREF_SCHEDULER_ENABLED, true) }
-                ServiceController.refreshServices(context)
+    @JvmStatic
+    fun getCalendarForEnd(context: Context): Calendar {
+        val sharedPreferences = Prefs.get(context)
+        val hour = sharedPreferences.getInt("scheduleToHour", 6)
+        val minute = sharedPreferences.getInt("scheduleToMinute", 0)
+        return Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, hour)
+            set(Calendar.MINUTE, minute)
+            clear(Calendar.SECOND)
+            if (timeInMillis < getCalendarForStart(context).timeInMillis) {
+                add(Calendar.DATE, 1)
             }
         }
+    }
 
-        @JvmStatic
-        fun disable(context: Context) {
-            val prefs = Prefs.get(context)
-            if (prefs.getBoolean(Constants.PREF_SCHEDULER_ENABLED, false)) {
-                prefs.edit { putBoolean(Constants.PREF_SCHEDULER_ENABLED, false) }
-                ServiceController.refreshServices(context)
-            }
+    @JvmStatic
+    fun isEnabled(context: Context): Boolean {
+        val prefs = Prefs.get(context)
+        return prefs.getBoolean(Constants.PREF_SCHEDULER_ENABLED, false)
+    }
+
+    @JvmStatic
+    fun enable(context: Context) {
+        val prefs = Prefs.get(context)
+        if (!prefs.getBoolean(Constants.PREF_SCHEDULER_ENABLED, false)) {
+            prefs.edit { putBoolean(Constants.PREF_SCHEDULER_ENABLED, true) }
+            scheduleWork(context)
+            evaluateSchedule(context)
+        }
+    }
+
+    @JvmStatic
+    fun disable(context: Context) {
+        val prefs = Prefs.get(context)
+        if (prefs.getBoolean(Constants.PREF_SCHEDULER_ENABLED, false)) {
+            prefs.edit { putBoolean(Constants.PREF_SCHEDULER_ENABLED, false) }
+            cancelWork(context)
+            context.stopService(Intent(context, OverlayService::class.java))
         }
     }
 }

--- a/app/src/main/java/com/d4rk/lowbrightness/services/SchedulerWorker.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/services/SchedulerWorker.kt
@@ -1,0 +1,15 @@
+package com.d4rk.lowbrightness.services
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+
+class SchedulerWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        SchedulerService.evaluateSchedule(applicationContext)
+        return Result.success()
+    }
+}

--- a/app/src/main/res/xml/preferences_permissions.xml
+++ b/app/src/main/res/xml/preferences_permissions.xml
@@ -44,11 +44,6 @@
             app:useSimpleSummaryProvider="true"
             app:iconSpaceReserved="false"/>
         <androidx.preference.Preference
-            app:title="@string/schedule_exact_alarm"
-            app:summary="@string/summary_preference_permissions_schedule_exact_alarm"
-            app:useSimpleSummaryProvider="true"
-            app:iconSpaceReserved="false"/>
-        <androidx.preference.Preference
             app:title="@string/system_alert_window"
             app:summary="@string/summary_preference_permissions_system_alert_window"
             app:useSimpleSummaryProvider="true"


### PR DESCRIPTION
## Summary
- add WorkManager dependency
- implement `SchedulerWorker` and refactor `SchedulerService` to object
- schedule/cancel hourly work in `ServiceController`
- remove exact alarm permission and legacy service entry
- cleanup scheduler enable screen

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew testDebugUnitTest --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841484034f8832da4a9f1c7f65cd7e6