### PR TITLE
Handle overlay service on Android 12+

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/receivers/OnBootBroadcastReceiver.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/receivers/OnBootBroadcastReceiver.kt
@@ -3,12 +3,18 @@ package com.d4rk.lowbrightness.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.d4rk.lowbrightness.base.ServiceController.refreshServices
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.WorkManager
+import com.d4rk.lowbrightness.services.BootWorker
 
 class OnBootBroadcastReceiver : BroadcastReceiver() {
-    override fun onReceive(context : Context , intent : Intent) {
+    override fun onReceive(context: Context, intent: Intent) {
         if (BOOT_COMPLETED_ACTION == intent.action) {
-            refreshServices(context)
+            val work = OneTimeWorkRequestBuilder<BootWorker>()
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .build()
+            WorkManager.getInstance(context).enqueue(work)
         }
     }
 

--- a/app/src/main/java/com/d4rk/lowbrightness/services/BootWorker.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/services/BootWorker.kt
@@ -2,25 +2,28 @@ package com.d4rk.lowbrightness.services
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
-import android.content.Context
 import androidx.core.app.NotificationCompat
-import androidx.core.content.getSystemService
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
+import androidx.core.content.getSystemService
+import android.content.Context
+import com.d4rk.lowbrightness.R
+import com.d4rk.lowbrightness.base.ServiceController
 
-class SchedulerWorker(
+class BootWorker(
     appContext: Context,
     params: WorkerParameters
 ) : CoroutineWorker(appContext, params) {
+
     override suspend fun doWork(): Result {
         setForeground(createForegroundInfo())
-        SchedulerService.evaluateSchedule(applicationContext)
+        ServiceController.refreshServices(applicationContext)
         return Result.success()
     }
 
     private fun createForegroundInfo(): ForegroundInfo {
-        val channelId = "scheduler_worker"
+        val channelId = "boot_worker"
         val channelName = applicationContext.getString(R.string.screen_overlay_notifications)
         val manager = applicationContext.getSystemService<NotificationManager>()
         manager?.createNotificationChannel(
@@ -31,6 +34,6 @@ class SchedulerWorker(
             .setContentTitle(applicationContext.getString(R.string.overlay_starting))
             .setOngoing(true)
             .build()
-        return ForegroundInfo(2002, notification)
+        return ForegroundInfo(2001, notification)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="app_usage_notifications">App Usage Notifications</string>
     <string name="update_notifications">Update Notifications</string>
     <string name="screen_overlay_notifications">Screen Overlay Notifications</string>
+    <string name="overlay_starting">Starting overlay...</string>
     <string name="ad_id">Ad id [AD_ID]</string>
     <string name="internet">Internet [INTERNET]</string>
     <string name="post_notifications">Post notifications [POST_NOTIFICATIONS]</string>


### PR DESCRIPTION
## Summary
- launch overlay at boot using WorkManager
- run schedule checks in a foreground worker
- show minimal notification when workers run

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414b7f186c832db7a47d93120e28ac