### PR TITLE
Move SharedPreferences keys to constants

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/MainActivity.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/MainActivity.kt
@@ -149,9 +149,9 @@ class MainActivity : AppCompatActivity(), IShowHideScheduler {
     }
 
     private fun startupScreen() {
-        val startupPreference = getSharedPreferences("startup", MODE_PRIVATE)
-        if (startupPreference.getBoolean("value", true)) {
-            startupPreference.edit { putBoolean("value", false) }
+        val startupPreference = getSharedPreferences(Constants.PREF_FILE_STARTUP, MODE_PRIVATE)
+        if (startupPreference.getBoolean(Constants.PREF_STARTUP_VALUE, true)) {
+            startupPreference.edit { putBoolean(Constants.PREF_STARTUP_VALUE, false) }
             startActivity(Intent(this, StartupActivity::class.java))
         }
     }

--- a/app/src/main/java/com/d4rk/lowbrightness/base/Constants.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/base/Constants.kt
@@ -1,8 +1,22 @@
 package com.d4rk.lowbrightness.base
 
 object Constants {
-    const val PREF_LOW_BRIGHTNESS_ENABLED : String = "filter_enabled"
-    const val PREF_DIM_LEVEL : String = "opacity_percent"
-    const val PREF_OVERLAY_COLOR : String = "overlay_color"
-    const val PREF_SCHEDULER_ENABLED : String = "scheduler_enabled"
+    const val PREF_LOW_BRIGHTNESS_ENABLED: String = "filter_enabled"
+    const val PREF_DIM_LEVEL: String = "opacity_percent"
+    const val PREF_OVERLAY_COLOR: String = "overlay_color"
+    const val PREF_SCHEDULER_ENABLED: String = "scheduler_enabled"
+
+    // Shared preferences file names
+    const val PREF_FILE_SETTINGS: String = "settings"
+    const val PREF_FILE_STARTUP: String = "startup"
+    const val PREF_FILE_APP_USAGE: String = "app_usage"
+
+    // Keys for additional preferences
+    const val PREF_STARTUP_VALUE: String = "value"
+    const val PREF_APP_USAGE_LAST_USED: String = "last_used"
+
+    const val PREF_SCHEDULE_FROM_HOUR: String = "scheduleFromHour"
+    const val PREF_SCHEDULE_FROM_MINUTE: String = "scheduleFromMinute"
+    const val PREF_SCHEDULE_TO_HOUR: String = "scheduleToHour"
+    const val PREF_SCHEDULE_TO_MINUTE: String = "scheduleToMinute"
 }

--- a/app/src/main/java/com/d4rk/lowbrightness/base/Prefs.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/base/Prefs.kt
@@ -5,7 +5,7 @@ import android.content.SharedPreferences
 
 object Prefs {
     @JvmStatic
-	fun get(c : Context) : SharedPreferences {
-        return c.getSharedPreferences("settings" , Context.MODE_PRIVATE)
+        fun get(c: Context): SharedPreferences {
+        return c.getSharedPreferences(Constants.PREF_FILE_SETTINGS, Context.MODE_PRIVATE)
     }
 }

--- a/app/src/main/java/com/d4rk/lowbrightness/helpers/AppUsageNotificationsManager.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/helpers/AppUsageNotificationsManager.kt
@@ -5,13 +5,14 @@ import android.content.Context
 import androidx.core.app.NotificationCompat
 import androidx.core.content.edit
 import com.d4rk.lowbrightness.R
+import com.d4rk.lowbrightness.base.Constants
 
 class AppUsageNotificationsManager(private val context: Context) {
     private val appUsageChannelId = "app_usage_channel"
     private val appUsageNotificationId = 0
     fun checkAndSendAppUsageNotification() {
-        val prefs = context.getSharedPreferences("app_usage", Context.MODE_PRIVATE)
-        val lastUsedTimestamp = prefs.getLong("last_used", 0)
+        val prefs = context.getSharedPreferences(Constants.PREF_FILE_APP_USAGE, Context.MODE_PRIVATE)
+        val lastUsedTimestamp = prefs.getLong(Constants.PREF_APP_USAGE_LAST_USED, 0)
         val currentTimestamp = System.currentTimeMillis()
         val notificationThreshold = 3 * 24 * 60 * 60 * 1000
         if (currentTimestamp - lastUsedTimestamp > notificationThreshold) {
@@ -25,6 +26,6 @@ class AppUsageNotificationsManager(private val context: Context) {
                 .setAutoCancel(true)
             notificationManager.notify(appUsageNotificationId, notificationBuilder.build())
         }
-        prefs.edit { putLong("last_used", currentTimestamp) }
+        prefs.edit { putLong(Constants.PREF_APP_USAGE_LAST_USED, currentTimestamp) }
     }
 }

--- a/app/src/main/java/com/d4rk/lowbrightness/notifications/SchedulerEnabledFragment.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/notifications/SchedulerEnabledFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.Fragment
 import com.d4rk.lowbrightness.R
 import com.d4rk.lowbrightness.base.ServiceController
 import com.d4rk.lowbrightness.base.Prefs
+import com.d4rk.lowbrightness.base.Constants
 import com.d4rk.lowbrightness.databinding.FragmentSchedulerEnabledBinding
 import com.d4rk.lowbrightness.helpers.IShowHideScheduler
 import com.d4rk.lowbrightness.services.SchedulerService
@@ -50,12 +51,12 @@ class SchedulerEnabledFragment : Fragment() {
         reloadButtonUIs()
         binding.buttonHourFrom.setOnClickListener {
             val sharedPreferences = Prefs.get(requireContext())
-            val scheduleFromHour = sharedPreferences.getInt("scheduleFromHour", 20)
-            val scheduleFromMinute = sharedPreferences.getInt("scheduleFromMinute", 0)
+            val scheduleFromHour = sharedPreferences.getInt(Constants.PREF_SCHEDULE_FROM_HOUR, 20)
+            val scheduleFromMinute = sharedPreferences.getInt(Constants.PREF_SCHEDULE_FROM_MINUTE, 0)
             val dialogTimePicker = TimePickerDialog.newInstance({ _, hourOfDay, minute, _ ->
                 Prefs.get(requireContext()).edit {
-                    putInt("scheduleFromHour", hourOfDay)
-                        .putInt("scheduleFromMinute", minute)
+                    putInt(Constants.PREF_SCHEDULE_FROM_HOUR, hourOfDay)
+                        .putInt(Constants.PREF_SCHEDULE_FROM_MINUTE, minute)
                 }
                 reloadButtonUIs()
             }, scheduleFromHour, scheduleFromMinute, true)
@@ -63,12 +64,12 @@ class SchedulerEnabledFragment : Fragment() {
         }
         binding.buttonHourTo.setOnClickListener {
             val sharedPreferences = Prefs.get(requireContext())
-            val scheduleToHour = sharedPreferences.getInt("scheduleToHour", 6)
-            val scheduleToMinute = sharedPreferences.getInt("scheduleToMinute", 0)
+            val scheduleToHour = sharedPreferences.getInt(Constants.PREF_SCHEDULE_TO_HOUR, 6)
+            val scheduleToMinute = sharedPreferences.getInt(Constants.PREF_SCHEDULE_TO_MINUTE, 0)
             val dialogTimePicker = TimePickerDialog.newInstance({ _, hourOfDay, minute, _ ->
                 Prefs.get(requireContext()).edit {
-                    putInt("scheduleToHour", hourOfDay)
-                        .putInt("scheduleToMinute", minute)
+                    putInt(Constants.PREF_SCHEDULE_TO_HOUR, hourOfDay)
+                        .putInt(Constants.PREF_SCHEDULE_TO_MINUTE, minute)
                 }
                 reloadButtonUIs()
             }, scheduleToHour, scheduleToMinute, true)
@@ -86,10 +87,10 @@ class SchedulerEnabledFragment : Fragment() {
         if (view == null) return
 
         val sharedPreferences = Prefs.get(requireContext())
-        val scheduleFromHour = sharedPreferences.getInt("scheduleFromHour", 20)
-        val scheduleFromMinute = sharedPreferences.getInt("scheduleFromMinute", 0)
-        val scheduleToHour = sharedPreferences.getInt("scheduleToHour", 6)
-        val scheduleToMinute = sharedPreferences.getInt("scheduleToMinute", 0)
+        val scheduleFromHour = sharedPreferences.getInt(Constants.PREF_SCHEDULE_FROM_HOUR, 20)
+        val scheduleFromMinute = sharedPreferences.getInt(Constants.PREF_SCHEDULE_FROM_MINUTE, 0)
+        val scheduleToHour = sharedPreferences.getInt(Constants.PREF_SCHEDULE_TO_HOUR, 6)
+        val scheduleToMinute = sharedPreferences.getInt(Constants.PREF_SCHEDULE_TO_MINUTE, 0)
 
         val cNow = Calendar.getInstance()
         val cStart = SchedulerService.getCalendarForStart(requireContext())

--- a/app/src/main/java/com/d4rk/lowbrightness/services/SchedulerService.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/services/SchedulerService.kt
@@ -63,8 +63,8 @@ object SchedulerService {
     @JvmStatic
     fun getCalendarForStart(context: Context): Calendar {
         val sharedPreferences = Prefs.get(context)
-        val scheduleFromHour = sharedPreferences.getInt("scheduleFromHour", 20)
-        val scheduleFromMinute = sharedPreferences.getInt("scheduleFromMinute", 0)
+        val scheduleFromHour = sharedPreferences.getInt(Constants.PREF_SCHEDULE_FROM_HOUR, 20)
+        val scheduleFromMinute = sharedPreferences.getInt(Constants.PREF_SCHEDULE_FROM_MINUTE, 0)
         return Calendar.getInstance().apply {
             set(Calendar.HOUR_OF_DAY, scheduleFromHour)
             set(Calendar.MINUTE, scheduleFromMinute)
@@ -75,8 +75,8 @@ object SchedulerService {
     @JvmStatic
     fun getCalendarForEnd(context: Context): Calendar {
         val sharedPreferences = Prefs.get(context)
-        val hour = sharedPreferences.getInt("scheduleToHour", 6)
-        val minute = sharedPreferences.getInt("scheduleToMinute", 0)
+        val hour = sharedPreferences.getInt(Constants.PREF_SCHEDULE_TO_HOUR, 6)
+        val minute = sharedPreferences.getInt(Constants.PREF_SCHEDULE_TO_MINUTE, 0)
         return Calendar.getInstance().apply {
             set(Calendar.HOUR_OF_DAY, hour)
             set(Calendar.MINUTE, minute)


### PR DESCRIPTION
## Summary
- centralize SharedPreferences keys in `Constants.kt`
- refactor usage across the codebase to use the new constants

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415143d430832d993a8f355f8d1365