### PR TITLE
Fix OverlayService null intent crash

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/services/OverlayService.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/services/OverlayService.kt
@@ -27,8 +27,13 @@ class OverlayService : Service() {
 
     override fun onBind(intent : Intent) : IBinder? = null
 
-    override fun onStartCommand(intent : Intent , flags : Int , startId : Int) : Int {
+    override fun onStartCommand(intent : Intent?, flags : Int, startId : Int) : Int {
         Log.d(tag, "onStartCommand")
+
+        if (intent == null) {
+            Log.w(tag, "Received null intent in onStartCommand")
+            return START_NOT_STICKY
+        }
         val sharedPreferences = Prefs.get(baseContext)
 
         if (!isEnabled(baseContext) || !ServiceController.canDrawOverlay(baseContext)) {


### PR DESCRIPTION
## Summary
- handle `null` intents in `OverlayService.onStartCommand`

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684153ee13bc832da104afa91c4f00fd