### PR TITLE
Add device resource checks for Play Core updates

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/helpers/DeviceStateUtils.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/helpers/DeviceStateUtils.kt
@@ -1,0 +1,37 @@
+package com.d4rk.lowbrightness.helpers
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.BatteryManager
+import android.os.Build
+import android.os.Environment
+import android.os.StatFs
+
+fun Context.hasSufficientStorage(minBytes: Long): Boolean {
+    val path = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        filesDir
+    } else {
+        Environment.getDataDirectory()
+    }
+    val stat = StatFs(path.path)
+    val availableBytes = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+        stat.availableBytes
+    } else {
+        stat.blockSizeLong * stat.availableBlocksLong
+    }
+    return availableBytes >= minBytes
+}
+
+fun Context.isBatteryLevelAcceptable(threshold: Int = 20): Boolean {
+    val manager = getSystemService(Context.BATTERY_SERVICE) as BatteryManager
+    val level = manager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+    return level >= threshold
+}
+
+fun Context.isNetworkAvailable(): Boolean {
+    val connectivityManager = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    val network = connectivityManager.activeNetwork ?: return false
+    val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+    return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="snack_unable_to_open_google_play_store">Unable to open Google Play Store.</string>
     <string name="snack_feedback">Thanks for rating us!</string>
     <string name="snack_copied_to_clipboard">Copied to clipboard!</string>
+    <string name="snack_update_conditions_not_met">Update postponed due to low battery, storage, or no network connection.</string>
     <string name="tooltip_agree">Accept the terms and conditions.</string>
     <string name="tooltip_button_hour_from">Time when your screen brightness will be adjusted to the level you set.</string>
     <string name="tooltip_button_hour_to">Time when your screen brightness will return to its normal level.</string>


### PR DESCRIPTION
## Summary
- add `DeviceStateUtils` with helpers to check battery, storage and network
- show a snackbar if update is postponed because resources are low
- use the new checks before starting in-app update flow

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841596bc960832da6dc2fb12a065a94