### PR TITLE
Migrate scheduler screen to compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,5 +115,6 @@ dependencies {
     implementation(dependencyNotation = libs.profileinstaller)
     implementation(dependencyNotation = libs.compose.color.picker)
     implementation(dependencyNotation = libs.compose.color.picker.android)
+    implementation(dependencyNotation = libs.androidx.work.runtime.ktx)
 
 }

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/domain/services/SchedulerService.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/domain/services/SchedulerService.kt
@@ -1,0 +1,101 @@
+package com.d4rk.lowbrightness.app.brightness.domain.services
+
+import android.content.Context
+import androidx.core.content.edit
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.d4rk.lowbrightness.app.brightness.domain.ext.sharedPreferences
+import com.d4rk.lowbrightness.app.brightness.ui.components.closeNightScreen
+import com.d4rk.lowbrightness.app.brightness.ui.components.runAsScheduled
+import com.d4rk.lowbrightness.app.brightness.ui.components.showNightScreen
+import java.util.Calendar
+import java.util.concurrent.TimeUnit
+
+object SchedulerService {
+    private const val WORK_NAME = "SchedulerWorker"
+    private const val PREF_SCHEDULER_ENABLED = "scheduler_enabled"
+    private const val PREF_SCHEDULE_FROM_HOUR = "scheduleFromHour"
+    private const val PREF_SCHEDULE_FROM_MINUTE = "scheduleFromMinute"
+    private const val PREF_SCHEDULE_TO_HOUR = "scheduleToHour"
+    private const val PREF_SCHEDULE_TO_MINUTE = "scheduleToMinute"
+
+    fun isEnabled(context: Context): Boolean =
+        context.sharedPreferences().getBoolean(PREF_SCHEDULER_ENABLED, false)
+
+    fun enable(context: Context) {
+        if (isEnabled(context)) return
+        context.sharedPreferences().edit { putBoolean(PREF_SCHEDULER_ENABLED, true) }
+        runAsScheduled = true
+        scheduleWork(context)
+        evaluateSchedule(context)
+    }
+
+    fun disable(context: Context) {
+        if (!isEnabled(context)) return
+        context.sharedPreferences().edit { putBoolean(PREF_SCHEDULER_ENABLED, false) }
+        runAsScheduled = false
+        WorkManager.getInstance(context.applicationContext).cancelUniqueWork(WORK_NAME)
+        closeNightScreen()
+    }
+
+    fun setFrom(context: Context, hour: Int, minute: Int) {
+        context.sharedPreferences().edit {
+            putInt(PREF_SCHEDULE_FROM_HOUR, hour)
+            putInt(PREF_SCHEDULE_FROM_MINUTE, minute)
+        }
+    }
+
+    fun setTo(context: Context, hour: Int, minute: Int) {
+        context.sharedPreferences().edit {
+            putInt(PREF_SCHEDULE_TO_HOUR, hour)
+            putInt(PREF_SCHEDULE_TO_MINUTE, minute)
+        }
+    }
+
+    fun getCalendarForStart(context: Context): Calendar {
+        val prefs = context.sharedPreferences()
+        val hour = prefs.getInt(PREF_SCHEDULE_FROM_HOUR, 20)
+        val minute = prefs.getInt(PREF_SCHEDULE_FROM_MINUTE, 0)
+        return Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, hour)
+            set(Calendar.MINUTE, minute)
+            clear(Calendar.SECOND)
+        }
+    }
+
+    fun getCalendarForEnd(context: Context): Calendar {
+        val prefs = context.sharedPreferences()
+        val hour = prefs.getInt(PREF_SCHEDULE_TO_HOUR, 6)
+        val minute = prefs.getInt(PREF_SCHEDULE_TO_MINUTE, 0)
+        return Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, hour)
+            set(Calendar.MINUTE, minute)
+            clear(Calendar.SECOND)
+            if (timeInMillis < getCalendarForStart(context).timeInMillis) {
+                add(Calendar.DATE, 1)
+            }
+        }
+    }
+
+    fun evaluateSchedule(context: Context) {
+        if (!runAsScheduled) return
+        val start = getCalendarForStart(context)
+        val end = getCalendarForEnd(context)
+        val now = Calendar.getInstance()
+        if (now.timeInMillis in start.timeInMillis..end.timeInMillis) {
+            showNightScreen()
+        } else {
+            closeNightScreen()
+        }
+    }
+
+    private fun scheduleWork(context: Context) {
+        val request = PeriodicWorkRequestBuilder<SchedulerWorker>(1, TimeUnit.HOURS).build()
+        WorkManager.getInstance(context.applicationContext).enqueueUniquePeriodicWork(
+            WORK_NAME,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
+        )
+    }
+}

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/domain/services/SchedulerWorker.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/domain/services/SchedulerWorker.kt
@@ -1,0 +1,15 @@
+package com.d4rk.lowbrightness.app.brightness.domain.services
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+
+class SchedulerWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        SchedulerService.evaluateSchedule(applicationContext)
+        return Result.success()
+    }
+}

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/BrightnessScreen.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/BrightnessScreen.kt
@@ -60,6 +60,7 @@ import com.d4rk.lowbrightness.app.brightness.ui.components.dialogs.ColorDialog
 import com.d4rk.lowbrightness.app.brightness.ui.components.dialogs.requestAllPermissionsWithAccessibilityAndShow
 import com.d4rk.lowbrightness.app.brightness.ui.components.screenAlpha
 import com.d4rk.lowbrightness.app.brightness.ui.components.screenColor
+import com.d4rk.lowbrightness.app.brightness.ui.ScheduleCard
 import com.d4rk.lowbrightness.ui.component.showToast
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -95,6 +96,7 @@ fun BrightnessScreen(paddingValues: PaddingValues) {
                 }
             )
         }
+        item { ScheduleCard() }
         item { BottomImage() }
     }
 }

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/ScheduleScreen.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/ScheduleScreen.kt
@@ -1,0 +1,118 @@
+package com.d4rk.lowbrightness.app.brightness.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
+import com.d4rk.lowbrightness.R
+import com.d4rk.lowbrightness.app.brightness.domain.services.SchedulerService
+import com.d4rk.lowbrightness.app.brightness.domain.ext.fragmentActivity
+import com.wdullaer.materialdatetimepicker.time.TimePickerDialog
+import kotlinx.coroutines.delay
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+
+@Composable
+fun ScheduleCard() {
+    val context = LocalContext.current
+
+    var enabled by remember { mutableStateOf(SchedulerService.isEnabled(context)) }
+    var startHour by remember { mutableIntStateOf(SchedulerService.getCalendarForStart(context).get(Calendar.HOUR_OF_DAY)) }
+    var startMinute by remember { mutableIntStateOf(SchedulerService.getCalendarForStart(context).get(Calendar.MINUTE)) }
+    var endHour by remember { mutableIntStateOf(SchedulerService.getCalendarForEnd(context).get(Calendar.HOUR_OF_DAY)) }
+    var endMinute by remember { mutableIntStateOf(SchedulerService.getCalendarForEnd(context).get(Calendar.MINUTE)) }
+    var remaining by remember { mutableStateOf("") }
+
+    LaunchedEffect(enabled, startHour, startMinute, endHour, endMinute) {
+        while (enabled) {
+            val now = Calendar.getInstance()
+            val start = SchedulerService.getCalendarForStart(context)
+            val end = SchedulerService.getCalendarForEnd(context)
+            remaining = if (now.timeInMillis > start.timeInMillis && now.timeInMillis < end.timeInMillis) {
+                val diff = end.timeInMillis - now.timeInMillis
+                val formatted = String.format(Locale.getDefault(), "%tT", diff - TimeZone.getDefault().rawOffset)
+                context.getString(R.string.time_remaining_to_lighten_label) + ": " + formatted
+            } else {
+                val diff = if (now.timeInMillis < start.timeInMillis) {
+                    start.timeInMillis - now.timeInMillis
+                } else {
+                    start.add(Calendar.DATE, 1)
+                    start.timeInMillis - now.timeInMillis
+                }
+                val formatted = String.format(Locale.getDefault(), "%tT", diff - TimeZone.getDefault().rawOffset)
+                context.getString(R.string.time_remaining_to_darken_label) + ": " + formatted
+            }
+            delay(1000)
+        }
+    }
+
+    Card(modifier = Modifier
+        .fillMaxWidth()
+        .padding(vertical = 10.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = context.getString(R.string.summary_scheduler))
+            Button(onClick = {
+                if (enabled) {
+                    SchedulerService.disable(context)
+                } else {
+                    SchedulerService.enable(context)
+                }
+                enabled = !enabled
+            }, modifier = Modifier.padding(top = 10.dp)) {
+                Text(text = if (enabled) context.getString(R.string.disable_scheduler) else context.getString(R.string.enable_scheduler))
+            }
+            if (enabled) {
+                Text(
+                    modifier = Modifier.padding(top = 10.dp),
+                    text = context.getString(R.string.enabled_only_during_this_interval),
+                    textAlign = TextAlign.Center
+                )
+                Row(modifier = Modifier.fillMaxWidth().padding(top = 10.dp)) {
+                    val activity = context.fragmentActivity as FragmentActivity?
+                    Button(onClick = {
+                        val dlg = TimePickerDialog.newInstance({ _, h, m, _ ->
+                            startHour = h
+                            startMinute = m
+                            SchedulerService.setFrom(context, h, m)
+                            SchedulerService.evaluateSchedule(context)
+                        }, startHour, startMinute, true)
+                        activity?.let { dlg.show(it.supportFragmentManager, "from") }
+                    }, modifier = Modifier.weight(1f)) {
+                        Text(String.format(Locale.getDefault(), "%02d:%02d", startHour, startMinute))
+                    }
+                    Button(onClick = {
+                        val dlg = TimePickerDialog.newInstance({ _, h, m, _ ->
+                            endHour = h
+                            endMinute = m
+                            SchedulerService.setTo(context, h, m)
+                            SchedulerService.evaluateSchedule(context)
+                        }, endHour, endMinute, true)
+                        activity?.let { dlg.show(it.supportFragmentManager, "to") }
+                    }, modifier = Modifier.weight(1f)) {
+                        Text(String.format(Locale.getDefault(), "%02d:%02d", endHour, endMinute))
+                    }
+                }
+                if (remaining.isNotEmpty()) {
+                    Text(text = remaining, modifier = Modifier.padding(top = 10.dp), textAlign = TextAlign.Center)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/ScheduleScreen.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/ScheduleScreen.kt
@@ -1,12 +1,17 @@
 package com.d4rk.lowbrightness.app.brightness.ui
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Card
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -15,8 +20,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentActivity
@@ -63,54 +71,98 @@ fun ScheduleCard() {
         }
     }
 
-    Card(modifier = Modifier
-        .fillMaxWidth()
-        .padding(vertical = 10.dp)) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(text = context.getString(R.string.summary_scheduler))
-            Button(onClick = {
-                if (enabled) {
-                    SchedulerService.disable(context)
-                } else {
-                    SchedulerService.enable(context)
-                }
-                enabled = !enabled
-            }, modifier = Modifier.padding(top = 10.dp)) {
-                Text(text = if (enabled) context.getString(R.string.disable_scheduler) else context.getString(R.string.enable_scheduler))
-            }
-            if (enabled) {
+    Card(
+        shape = MaterialTheme.shapes.extraLarge,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 10.dp)
+            .animateContentSize()
+    ) {
+        Column {
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.primary)
+                    .padding(12.dp),
+                contentAlignment = Alignment.Center
+            ) {
                 Text(
-                    modifier = Modifier.padding(top = 10.dp),
-                    text = context.getString(R.string.enabled_only_during_this_interval),
-                    textAlign = TextAlign.Center
+                    text = stringResource(id = R.string.schedule),
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onPrimary
                 )
-                Row(modifier = Modifier.fillMaxWidth().padding(top = 10.dp)) {
-                    val activity = context.fragmentActivity as FragmentActivity?
-                    Button(onClick = {
-                        val dlg = TimePickerDialog.newInstance({ _, h, m, _ ->
-                            startHour = h
-                            startMinute = m
-                            SchedulerService.setFrom(context, h, m)
-                            SchedulerService.evaluateSchedule(context)
-                        }, startHour, startMinute, true)
-                        activity?.let { dlg.show(it.supportFragmentManager, "from") }
-                    }, modifier = Modifier.weight(1f)) {
-                        Text(String.format(Locale.getDefault(), "%02d:%02d", startHour, startMinute))
-                    }
-                    Button(onClick = {
-                        val dlg = TimePickerDialog.newInstance({ _, h, m, _ ->
-                            endHour = h
-                            endMinute = m
-                            SchedulerService.setTo(context, h, m)
-                            SchedulerService.evaluateSchedule(context)
-                        }, endHour, endMinute, true)
-                        activity?.let { dlg.show(it.supportFragmentManager, "to") }
-                    }, modifier = Modifier.weight(1f)) {
-                        Text(String.format(Locale.getDefault(), "%02d:%02d", endHour, endMinute))
-                    }
+            }
+
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = stringResource(id = R.string.summary_scheduler),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Button(
+                    onClick = {
+                        if (enabled) {
+                            SchedulerService.disable(context)
+                        } else {
+                            SchedulerService.enable(context)
+                        }
+                        enabled = !enabled
+                    },
+                    modifier = Modifier
+                        .padding(top = 10.dp)
+                        .align(Alignment.CenterHorizontally)
+                ) {
+                    Text(
+                        text = if (enabled) stringResource(id = R.string.disable_scheduler)
+                        else stringResource(id = R.string.enable_scheduler)
+                    )
                 }
-                if (remaining.isNotEmpty()) {
-                    Text(text = remaining, modifier = Modifier.padding(top = 10.dp), textAlign = TextAlign.Center)
+                if (enabled) {
+                    Text(
+                        modifier = Modifier.padding(top = 10.dp),
+                        text = stringResource(id = R.string.enabled_only_during_this_interval),
+                        textAlign = TextAlign.Center
+                    )
+                    Row(modifier = Modifier.fillMaxWidth().padding(top = 10.dp)) {
+                        val activity = context.fragmentActivity as FragmentActivity?
+                        Button(
+                            onClick = {
+                                val dlg = TimePickerDialog.newInstance({ _, h, m, _ ->
+                                    startHour = h
+                                    startMinute = m
+                                    SchedulerService.setFrom(context, h, m)
+                                    SchedulerService.evaluateSchedule(context)
+                                }, startHour, startMinute, true)
+                                activity?.let { dlg.show(it.supportFragmentManager, "from") }
+                            },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(String.format(Locale.getDefault(), "%02d:%02d", startHour, startMinute))
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Button(
+                            onClick = {
+                                val dlg = TimePickerDialog.newInstance({ _, h, m, _ ->
+                                    endHour = h
+                                    endMinute = m
+                                    SchedulerService.setTo(context, h, m)
+                                    SchedulerService.evaluateSchedule(context)
+                                }, endHour, endMinute, true)
+                                activity?.let { dlg.show(it.supportFragmentManager, "to") }
+                            },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(String.format(Locale.getDefault(), "%02d:%02d", endHour, endMinute))
+                        }
+                    }
+                    if (remaining.isNotEmpty()) {
+                        Text(
+                            text = remaining,
+                            modifier = Modifier.padding(top = 10.dp),
+                            textAlign = TextAlign.Center
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,5 +44,15 @@
     <string name="alert_window_permission">alert window</string>
     <string name="post_notification_permission">post notification</string>
     <string name="night_screen_is_running">Night Screen is activated…</string>
+    <string name="schedule">Schedule</string>
+    <string name="enable_scheduler">Enable scheduler</string>
+    <string name="disable_scheduler">Disable scheduler</string>
+    <string name="enabled_only_during_this_interval">Enabled only during this interval:</string>
+    <string name="time_remaining_to_darken_label">Screen brightness will be reduced in</string>
+    <string name="time_remaining_to_lighten_label">Original brightness will be restored in</string>
+    <string name="summary_scheduler">Schedule the period when the screen should automatically darken, to reduce eye strain and make it more comfortable to read in dark environments.</string>
+    <string name="tooltip_button_hour_from">Time when your screen brightness will be adjusted to the level you set.</string>
+    <string name="tooltip_button_hour_to">Time when your screen brightness will return to its normal level.</string>
+    <string name="tooltip_enable_scheduler">Enable the scheduler to automatically adjust your screen brightness.</string>
     <string name="accessibility_service_description">Use accessibility service to implement the function of reducing screen brightness</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ accompanist = "0.36.0"
 profileinstaller = "1.4.1"
 colorPicker = "0.7.0"
 xxpermissions = "18.3"
+workRuntimeKtx = "2.10.1"
 
 [libraries]
 androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationUiKtx" }
@@ -29,6 +30,7 @@ accompanist-navigation-animation = { module = "com.google.accompanist:accompanis
 profileinstaller = { module = "androidx.profileinstaller:profileinstaller", version.ref = "profileinstaller" }
 compose-color-picker = { module = "com.godaddy.android.colorpicker:compose-color-picker", version.ref = "colorPicker" }
 compose-color-picker-android = { module = "com.godaddy.android.colorpicker:compose-color-picker-android", version.ref = "colorPicker" }
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add WorkManager dependency
- implement `SchedulerService` and `SchedulerWorker`
- create Compose `ScheduleCard`
- integrate scheduler card in `BrightnessScreen`
- add required strings

## Testing
- `./gradlew help --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68446a8bc6fc832d8f4eb384f1545cf1