### PR TITLE
Add permission documentation and FAQs

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/app/settings/settings/utils/providers/PermissionsSettingsProvider.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/settings/settings/utils/providers/PermissionsSettingsProvider.kt
@@ -39,6 +39,10 @@ class PermissionsSettingsProvider : PermissionsProvider {
                             summary = context.getString(R.string.summary_preference_permissions_internet) ,
                         ) ,
                         SettingsPreference(
+                            title = context.getString(com.d4rk.lowbrightness.R.string.receive_boot_completed) ,
+                            summary = context.getString(com.d4rk.lowbrightness.R.string.summary_preference_permissions_receive_boot_completed) ,
+                        ) ,
+                        SettingsPreference(
                             title = context.getString(R.string.wake_lock) ,
                             summary = context.getString(R.string.summary_preference_permissions_wake_lock) ,
                         ) ,
@@ -57,6 +61,14 @@ class PermissionsSettingsProvider : PermissionsProvider {
                         SettingsPreference(
                             title = context.getString(R.string.access_notification_policy) ,
                             summary = context.getString(R.string.summary_preference_permissions_access_notification_policy) ,
+                        ) ,
+                        SettingsPreference(
+                            title = context.getString(com.d4rk.lowbrightness.R.string.system_alert_window) ,
+                            summary = context.getString(com.d4rk.lowbrightness.R.string.summary_preference_permissions_system_alert_window) ,
+                        ) ,
+                        SettingsPreference(
+                            title = context.getString(com.d4rk.lowbrightness.R.string.write_settings) ,
+                            summary = context.getString(com.d4rk.lowbrightness.R.string.summary_preference_permissions_write_settings) ,
                         ) ,
                     ) ,
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,4 +55,31 @@
     <string name="tooltip_button_hour_to">Time when your screen brightness will return to its normal level.</string>
     <string name="tooltip_enable_scheduler">Enable the scheduler to automatically adjust your screen brightness.</string>
     <string name="accessibility_service_description">Use accessibility service to implement the function of reducing screen brightness</string>
+    <!-- Permissions -->
+    <string name="receive_boot_completed">Receive boot completed [RECEIVE_BOOT_COMPLETED]</string>
+    <string name="summary_preference_permissions_receive_boot_completed">Allows the app to restart its services after the device boots so scheduled dimming continues to work.</string>
+    <string name="system_alert_window">System alert window [SYSTEM_ALERT_WINDOW]</string>
+    <string name="summary_preference_permissions_system_alert_window">Allows the app to draw overlay views over other apps, enabling the dimming layer.</string>
+    <string name="write_settings">Write settings [WRITE_SETTINGS]</string>
+    <string name="summary_preference_permissions_write_settings">Allows the app to modify system settings such as screen brightness.</string>
+
+    <!-- FAQ -->
+    <string name="question_1" translatable="false">What is Low Brightness?</string>
+    <string name="summary_preference_faq_1" translatable="false">Low Brightness lets you dim the screen beyond the system minimum for comfortable viewing in dark environments.</string>
+    <string name="question_2" translatable="false">Why does the app need the overlay permission?</string>
+    <string name="summary_preference_faq_2" translatable="false">It allows the app to display a dimming overlay on top of other apps.</string>
+    <string name="question_3" translatable="false">Why does the app request to modify system settings?</string>
+    <string name="summary_preference_faq_3" translatable="false">This permission lets the app adjust system brightness values so the filter can apply correctly.</string>
+    <string name="question_4" translatable="false">Why is the boot permission required?</string>
+    <string name="summary_preference_faq_4" translatable="false">The app uses it to restore brightness and notifications after you restart the device.</string>
+    <string name="question_5" translatable="false">Does the app work without internet?</string>
+    <string name="summary_preference_faq_5" translatable="false">Yes. Internet is only used for update checks and optional error reports.</string>
+    <string name="question_6" translatable="false">Is the app free?</string>
+    <string name="summary_preference_faq_6" translatable="false">All core features are free and open source. Donations are optional.</string>
+    <string name="question_7" translatable="false">Can I change the overlay color?</string>
+    <string name="summary_preference_faq_7" translatable="false">Yes. You can select any color from the settings screen.</string>
+    <string name="question_8" translatable="false">Why is there a persistent notification?</string>
+    <string name="summary_preference_faq_8" translatable="false">The notification keeps the dimming service running so it is not killed by the system.</string>
+    <string name="question_9" translatable="false">How can I contact support?</string>
+    <string name="summary_preference_faq_9" translatable="false">Send feedback from the app or open an issue on GitHub.</string>
 </resources>


### PR DESCRIPTION
## Summary
- document three extra permissions
- integrate new permissions in settings provider
- add FAQ entries about the app

## Testing
- `./gradlew --version`
- ❌ `./gradlew assembleDebug -x lint` *(failed: cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6846fcb139bc832d93d0da22df69ad93