### PR TITLE
Refactor brightness screen spacing

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/BrightnessScreen.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/BrightnessScreen.kt
@@ -19,10 +19,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.lowbrightness.R
 import com.d4rk.lowbrightness.app.brightness.domain.ext.activity
 import com.d4rk.lowbrightness.app.brightness.domain.ext.plus
@@ -67,7 +66,7 @@ fun BrightnessScreen(paddingValues: PaddingValues) {
             .verticalScroll(rememberScrollState())
             .padding(
                 PaddingValues(
-                    horizontal = 20.dp,
+                    horizontal = SizeConstants.LargeIncreasedSize,
                 ) + paddingValues
             ) ,
     ) {

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/BottomImage.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/BottomImage.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.lowbrightness.R
 
 @Composable
@@ -19,7 +20,7 @@ fun BottomImage() {
     Card(
         shape = MaterialTheme.shapes.extraLarge, modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 10.dp)
+            .padding(vertical = SizeConstants.SmallSize + SizeConstants.ExtraTinySize)
             .height(192.dp)
     ) {
         Image(

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/ColorCard.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/ColorCard.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.lowbrightness.R
 import com.d4rk.lowbrightness.app.brightness.ui.components.dialogs.ColorDialog
 
@@ -34,7 +34,7 @@ fun ColorCard() {
     Card(
         shape = MaterialTheme.shapes.extraLarge, modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 10.dp)
+            .padding(vertical = SizeConstants.SmallSize + SizeConstants.ExtraTinySize)
     ) {
         Column {
 
@@ -42,7 +42,7 @@ fun ColorCard() {
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(MaterialTheme.colorScheme.primary)
-                    .padding(12.dp), contentAlignment = Alignment.Center
+                    .padding(SizeConstants.MediumSize), contentAlignment = Alignment.Center
             ) {
                 Text(
                     text = stringResource(id = R.string.customize_overlay_color),
@@ -52,11 +52,11 @@ fun ColorCard() {
                 )
             }
 
-            Column(modifier = Modifier.padding(16.dp)) {
+            Column(modifier = Modifier.padding(SizeConstants.LargeSize)) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 8.dp), verticalAlignment = Alignment.CenterVertically
+                        .padding(top = SizeConstants.SmallSize), verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
                         modifier = Modifier.weight(1f),
@@ -68,7 +68,7 @@ fun ColorCard() {
                         onClick = { showDialog = true }) {
                         Box(
                             modifier = Modifier
-                                .size(48.dp)
+                                .size(SizeConstants.ExtraExtraLargeSize)
                                 .background(
                                     color = Color(calculatedColor),
                                     shape = RoundedCornerShape(percent = 50)

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/HomeItem.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/HomeItem.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -17,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeIncreasedHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @Composable
@@ -45,8 +45,7 @@ fun HomeItem(
             tint = MaterialTheme.colorScheme.primary
         )
 
-        Spacer(modifier = Modifier.width(width = SizeConstants.LargeIncreasedSize)) // TODO: Replace after library update
-        //LargeIncreasedHorizontalSpacer()
+        LargeIncreasedHorizontalSpacer()
 
         Text(
             text = text,

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/IntensityCard.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/IntensityCard.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.lowbrightness.R
 
 @Composable
@@ -28,7 +28,7 @@ fun IntensityCard() {
     Card(
         shape = MaterialTheme.shapes.extraLarge, modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 10.dp)
+            .padding(vertical = SizeConstants.SmallSize + SizeConstants.ExtraTinySize)
     ) {
         Column {
 
@@ -36,7 +36,7 @@ fun IntensityCard() {
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(MaterialTheme.colorScheme.primary)
-                    .padding(12.dp), contentAlignment = Alignment.Center
+                    .padding(SizeConstants.MediumSize), contentAlignment = Alignment.Center
             ) {
                 Text(
                     text = stringResource(id = R.string.intensity),
@@ -46,14 +46,14 @@ fun IntensityCard() {
                 )
             }
 
-            Column(modifier = Modifier.padding(16.dp)) {
+            Column(modifier = Modifier.padding(SizeConstants.LargeSize)) {
                 Text(
                     text = stringResource(id = R.string.summary_brightness),
                     style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(top = 8.dp)
+                    modifier = Modifier.padding(top = SizeConstants.SmallSize)
                 )
                 Slider(
-                    modifier = Modifier.padding(top = 8.dp).bounceClick(), value = alpha, onValueChange = {
+                    modifier = Modifier.padding(top = SizeConstants.SmallSize).bounceClick(), value = alpha, onValueChange = {
                         alpha = it
                         screenAlpha = it
                     }, valueRange = alphaRange

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/ScheduleCard.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/ScheduleCard.kt
@@ -31,8 +31,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraSmallHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.lowbrightness.R
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccessTime
@@ -84,7 +86,7 @@ fun ScheduleCard() {
         shape = MaterialTheme.shapes.extraLarge,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 10.dp)
+            .padding(vertical = SizeConstants.SmallSize + SizeConstants.ExtraTinySize)
     ) {
         Column {
 
@@ -92,7 +94,7 @@ fun ScheduleCard() {
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(MaterialTheme.colorScheme.primary)
-                    .padding(12.dp),
+                    .padding(SizeConstants.MediumSize),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
@@ -103,7 +105,7 @@ fun ScheduleCard() {
                 )
             }
 
-            Column(modifier = Modifier.padding(16.dp)) {
+            Column(modifier = Modifier.padding(SizeConstants.LargeSize)) {
                 Text(
                     text = stringResource(id = R.string.summary_scheduler),
                     style = MaterialTheme.typography.bodyMedium
@@ -118,14 +120,14 @@ fun ScheduleCard() {
                         enabled = !enabled
                     },
                     modifier = Modifier
-                        .padding(top = 10.dp)
+                        .padding(top = SizeConstants.SmallSize + SizeConstants.ExtraTinySize)
                         .align(Alignment.CenterHorizontally).animateContentSize().bounceClick()
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.PowerSettingsNew,
                         contentDescription = null
                     )
-                    Spacer(modifier = Modifier.width(8.dp))
+                    SmallHorizontalSpacer()
                     Text(
                         text = if (enabled) stringResource(id = R.string.disable_scheduler)
                         else stringResource(id = R.string.enable_scheduler),
@@ -139,11 +141,11 @@ fun ScheduleCard() {
                 ) {
                     Column {
                         Text(
-                            modifier = Modifier.padding(top = 10.dp),
+                            modifier = Modifier.padding(top = SizeConstants.SmallSize + SizeConstants.ExtraTinySize),
                             text = stringResource(id = R.string.enabled_only_during_this_interval),
                             textAlign = TextAlign.Center
                         )
-                        Row(modifier = Modifier.fillMaxWidth().padding(top = 10.dp)) {
+                        Row(modifier = Modifier.fillMaxWidth().padding(top = SizeConstants.SmallSize + SizeConstants.ExtraTinySize)) {
                             val activity = context.fragmentActivity
                             OutlinedButton(
                                 onClick = {
@@ -161,10 +163,10 @@ fun ScheduleCard() {
                                     imageVector = Icons.Outlined.AccessTime,
                                     contentDescription = null
                                 )
-                                Spacer(modifier = Modifier.width(4.dp))
+                                ExtraSmallHorizontalSpacer()
                                 Text(String.format(Locale.getDefault(), "%02d:%02d", startHour, startMinute))
                             }
-                            Spacer(modifier = Modifier.width(8.dp))
+                            SmallHorizontalSpacer()
                             OutlinedButton(
                                 onClick = {
                                     val dlg = TimePickerDialog.newInstance({ _, h, m, _ ->
@@ -181,14 +183,14 @@ fun ScheduleCard() {
                                     imageVector = Icons.Outlined.TimerOff,
                                     contentDescription = null
                                 )
-                                Spacer(modifier = Modifier.width(4.dp))
+                                ExtraSmallHorizontalSpacer()
                                 Text(String.format(Locale.getDefault(), "%02d:%02d", endHour, endMinute))
                             }
                         }
                         if (remaining.isNotEmpty()) {
                             Text(
                                 text = remaining,
-                                modifier = Modifier.padding(top = 10.dp),
+                                modifier = Modifier.padding(top = SizeConstants.SmallSize + SizeConstants.ExtraTinySize),
                                 textAlign = TextAlign.Center
                             )
                         }

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/dialogs/AlphaDialog.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/dialogs/AlphaDialog.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.lowbrightness.R
 import com.d4rk.lowbrightness.app.brightness.ui.components.alphaRange
 
@@ -68,7 +69,7 @@ fun AlphaDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(70.dp)
-                        .background(color = color, shape = RoundedCornerShape(20.dp))
+                        .background(color = color, shape = RoundedCornerShape(SizeConstants.LargeIncreasedSize))
                         .wrapContentHeight(),
                     text = String.format("%.1f", alpha * 100) + "%",
                     style = MaterialTheme.typography.bodyLarge.copy(
@@ -82,7 +83,7 @@ fun AlphaDialog(
                     color = Color.White
                 )
                 Slider(
-                    modifier = Modifier.padding(top = 10.dp),
+                    modifier = Modifier.padding(top = SizeConstants.SmallSize + SizeConstants.ExtraTinySize),
                     value = alpha,
                     valueRange = alphaRange,
                     onValueChange = {


### PR DESCRIPTION
## Summary
- replace hard-coded dp with AppToolkit `SizeConstants`
- use AppToolkit spacer components

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684952f3e304832da9fc854fd0f45923