### PR TITLE
Refactor spacers and icon sizes

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/HomeItem.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/HomeItem.kt
@@ -2,11 +2,9 @@ package com.d4rk.lowbrightness.app.brightness.ui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -17,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeIncreasedHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @Composable
@@ -45,8 +44,7 @@ fun HomeItem(
             tint = MaterialTheme.colorScheme.primary
         )
 
-        //LargeIncreasedHorizontalSpacer // TODO: take from lib after update
-        Spacer(modifier = Modifier.width(width = SizeConstants.LargeIncreasedSize))
+        LargeIncreasedHorizontalSpacer()
 
         Text(
             text = text,

--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/ScheduleCard.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/ScheduleCard.kt
@@ -8,10 +8,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
@@ -32,7 +31,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
-import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraSmallHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.lowbrightness.R
@@ -124,10 +123,11 @@ fun ScheduleCard() {
                         .align(Alignment.CenterHorizontally).animateContentSize().bounceClick()
                 ) {
                     Icon(
+                        modifier = Modifier.size(SizeConstants.ButtonIconSize),
                         imageVector = Icons.Outlined.PowerSettingsNew,
                         contentDescription = null
                     )
-                    SmallHorizontalSpacer()
+                    ButtonIconSpacer()
                     Text(
                         text = if (enabled) stringResource(id = R.string.disable_scheduler)
                         else stringResource(id = R.string.enable_scheduler),
@@ -160,10 +160,11 @@ fun ScheduleCard() {
                                 modifier = Modifier.weight(1f).bounceClick()
                             ) {
                                 Icon(
+                                    modifier = Modifier.size(SizeConstants.ButtonIconSize),
                                     imageVector = Icons.Outlined.AccessTime,
                                     contentDescription = null
                                 )
-                                ExtraSmallHorizontalSpacer()
+                                ButtonIconSpacer()
                                 Text(String.format(Locale.getDefault(), "%02d:%02d", startHour, startMinute))
                             }
                             SmallHorizontalSpacer()
@@ -180,10 +181,11 @@ fun ScheduleCard() {
                                 modifier = Modifier.weight(1f).bounceClick()
                             ) {
                                 Icon(
+                                    modifier = Modifier.size(SizeConstants.ButtonIconSize),
                                     imageVector = Icons.Outlined.TimerOff,
                                     contentDescription = null
                                 )
-                                ExtraSmallHorizontalSpacer()
+                                ButtonIconSpacer()
                                 Text(String.format(Locale.getDefault(), "%02d:%02d", endHour, endMinute))
                             }
                         }


### PR DESCRIPTION
## Summary
- use AppToolkit `LargeIncreasedHorizontalSpacer` in `HomeItem`
- apply `ButtonIconSpacer` and `ButtonIconSize` to buttons in `ScheduleCard`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849730035e4832da25060417f7f8855