### PR TITLE
Fix overlay not appearing by adding view to WindowManager

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/LayerView.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/LayerView.kt
@@ -16,6 +16,9 @@ import com.d4rk.lowbrightness.app.brightness.domain.util.screenWidth
 
 class LayerView(context: Context) : View(context) {
 
+    private val windowManager =
+        context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+
     var layoutParams = WindowManager.LayoutParams(
         context.screenWidth,
         context.screenHeight,
@@ -50,14 +53,18 @@ class LayerView(context: Context) : View(context) {
 
     fun visible() {
         if (isVisible) return
-//        windowManager.addView(this, layoutParams)
+        if (!isAttachedToWindow) {
+            windowManager.addView(this, layoutParams)
+        }
         visibility = VISIBLE
     }
 
     fun gone() {
         if (!isVisible) return
         visibility = GONE
-//        windowManager.removeView(this)
+        if (isAttachedToWindow) {
+            windowManager.removeView(this)
+        }
     }
 
     init {


### PR DESCRIPTION
## Summary
- manage overlay visibility directly via WindowManager in `LayerView`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ed100b0c832d8723f57f2c7e518d