### PR TITLE
Fix overlay view re-add bug

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/domain/services/OverlayAccessibilityService.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/domain/services/OverlayAccessibilityService.kt
@@ -31,15 +31,21 @@ class OverlayAccessibilityService : AccessibilityService() {
     }
 
     override fun onServiceConnected() {
-        (getSystemService(WINDOW_SERVICE) as WindowManager).addView(
-            layerView,
-            layerView.layoutParams
-        )
+        val windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
+        if (!layerView.isAttachedToWindow) {
+            windowManager.addView(
+                layerView,
+                layerView.layoutParams
+            )
+        }
     }
 
     override fun onDestroy() {
         super.onDestroy()
 
+        if (layerView.isAttachedToWindow) {
+            (getSystemService(WINDOW_SERVICE) as WindowManager).removeView(layerView)
+        }
         closeNightScreen()
     }
 }


### PR DESCRIPTION
## Summary
- prevent adding overlay view more than once by checking `isAttachedToWindow`
- remove the overlay view when the service is destroyed

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f128231e4832da52704201645a9e4