### PR TITLE
Fix overlay service crash

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/domain/services/OverlayAccessibilityService.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/domain/services/OverlayAccessibilityService.kt
@@ -31,12 +31,16 @@ class OverlayAccessibilityService : AccessibilityService() {
     }
 
     override fun onServiceConnected() {
-        val windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
+        val windowManager = applicationContext.getSystemService(WINDOW_SERVICE) as WindowManager
         if (!layerView.isAttachedToWindow) {
-            windowManager.addView(
-                layerView,
-                layerView.layoutParams
-            )
+            try {
+                windowManager.addView(
+                    layerView,
+                    layerView.layoutParams
+                )
+            } catch (e: WindowManager.BadTokenException) {
+                // Ignore attempt if token is no longer valid
+            }
         }
     }
 
@@ -44,7 +48,7 @@ class OverlayAccessibilityService : AccessibilityService() {
         super.onDestroy()
 
         if (layerView.isAttachedToWindow) {
-            (getSystemService(WINDOW_SERVICE) as WindowManager).removeView(layerView)
+            (applicationContext.getSystemService(WINDOW_SERVICE) as WindowManager).removeView(layerView)
         }
         closeNightScreen()
     }


### PR DESCRIPTION
## Summary
- handle token errors when attaching overlay
- use `applicationContext` for overlay window manager

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68579d32e718832dbcabf37e4b8df07d