### PR TITLE
Ensure overlay type updates when service enabled

### DIFF
--- a/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/LayerView.kt
+++ b/app/src/main/java/com/d4rk/lowbrightness/app/brightness/ui/components/LayerView.kt
@@ -62,10 +62,19 @@ class LayerView(context: Context) : View(context) {
 
     fun visible() {
         if (isVisible) return
+
+        val newType = overlayType()
+
         if (!isAttachedToWindow) {
-            layoutParams.type = overlayType()
+            layoutParams.type = newType
+            windowManager.addView(this, layoutParams)
+        } else if (layoutParams.type != newType) {
+            // Window type cannot be changed while attached. Reattach with the new type.
+            windowManager.removeView(this)
+            layoutParams.type = newType
             windowManager.addView(this, layoutParams)
         }
+
         visibility = VISIBLE
     }
 


### PR DESCRIPTION
## Summary
- fix regression in overlay type assignment
- reattach view if overlay type needs updating

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*
- `./gradlew lint --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ae2f1478832dae3aab4c70308c5b