### PR TITLE
Fix Quick Settings tile service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,7 +61,7 @@
 
         <service
             android:name=".app.brightness.domain.services.NightScreenService"
-            android:exported="false"
+            android:exported="true"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />


### PR DESCRIPTION
## Summary
- export the Quick Settings Tile service in the manifest so the system can start it

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e885a160832d8f3033dc0aca0410